### PR TITLE
Invert ToggleSwitch value interpretation

### DIFF
--- a/lib/components/toggle_switch/toggle_switch.dart
+++ b/lib/components/toggle_switch/toggle_switch.dart
@@ -89,11 +89,11 @@ class _TUIToggleSwitchState extends State<TUIToggleSwitch>
                   child: Container(
                       alignment: widget.value
                           ? ((Directionality.of(context) == TextDirection.rtl)
-                              ? Alignment.centerRight
-                              : Alignment.centerLeft)
-                          : ((Directionality.of(context) == TextDirection.rtl)
                               ? Alignment.centerLeft
-                              : Alignment.centerRight),
+                              : Alignment.centerRight)
+                          : ((Directionality.of(context) == TextDirection.rtl)
+                              ? Alignment.centerRight
+                              : Alignment.centerLeft),
                       child: getThumb(context)),
                 ),
               ),

--- a/lib/components/toggle_switch/toggle_switch.dart
+++ b/lib/components/toggle_switch/toggle_switch.dart
@@ -137,15 +137,15 @@ class _TUIToggleSwitchState extends State<TUIToggleSwitch>
 
     if (widget.value) {
       return Icon(
-        FluentIcons.dismiss_12_regular,
-        size: 16,
-        color: colors.constantLight,
-      );
-    } else {
-      return Icon(
         Icons.check,
         size: 16,
         color: isEnabled() ? colors.primary : colors.constantLight,
+      );
+    } else {
+      return Icon(
+        FluentIcons.dismiss_12_regular,
+        size: 16,
+        color: colors.constantLight,
       );
     }
   }

--- a/lib/components/toggle_switch/toggle_switch.dart
+++ b/lib/components/toggle_switch/toggle_switch.dart
@@ -126,8 +126,8 @@ class _TUIToggleSwitchState extends State<TUIToggleSwitch>
 
     return isEnabled()
         ? widget.value
-            ? colors.constantDark
-            : colors.constantLight
+            ? colors.constantLight
+            : colors.constantDark
         : colors.disabledContent;
   }
 

--- a/lib/components/toggle_switch/toggle_switch.dart
+++ b/lib/components/toggle_switch/toggle_switch.dart
@@ -68,36 +68,32 @@ class _TUIToggleSwitchState extends State<TUIToggleSwitch>
                   : widget.onChanged!(false);
             }
           },
-          child: Row(
-            children: [
-              Container(
-                width: 40.0,
-                height: 24.0,
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(24.0),
-                  color: _circleAnimation!.value == Alignment.centerLeft
-                      ? isEnabled()
-                          ? colors.surfaceVariant
-                          : colors.disabledBackground
-                      : isEnabled()
-                          ? colors.primary
-                          : colors.disabledBackground,
-                ),
-                child: Padding(
-                  padding: const EdgeInsets.only(
-                      top: 2.0, bottom: 2.0, right: 2.0, left: 2.0),
-                  child: Container(
-                      alignment: widget.value
-                          ? ((Directionality.of(context) == TextDirection.rtl)
-                              ? Alignment.centerLeft
-                              : Alignment.centerRight)
-                          : ((Directionality.of(context) == TextDirection.rtl)
-                              ? Alignment.centerRight
-                              : Alignment.centerLeft),
-                      child: getThumb(context)),
-                ),
-              ),
-            ],
+          child: Container(
+            width: 40.0,
+            height: 24.0,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(24.0),
+              color: _circleAnimation!.value == Alignment.centerLeft
+                  ? isEnabled()
+                      ? colors.surfaceVariant
+                      : colors.disabledBackground
+                  : isEnabled()
+                      ? colors.primary
+                      : colors.disabledBackground,
+            ),
+            child: Padding(
+              padding: const EdgeInsets.only(
+                  top: 2.0, bottom: 2.0, right: 2.0, left: 2.0),
+              child: Container(
+                  alignment: widget.value
+                      ? ((Directionality.of(context) == TextDirection.rtl)
+                          ? Alignment.centerLeft
+                          : Alignment.centerRight)
+                      : ((Directionality.of(context) == TextDirection.rtl)
+                          ? Alignment.centerRight
+                          : Alignment.centerLeft),
+                  child: getThumb(context)),
+            ),
           ),
         );
       },

--- a/lib/components/toggle_switch/toggle_switch.dart
+++ b/lib/components/toggle_switch/toggle_switch.dart
@@ -77,10 +77,10 @@ class _TUIToggleSwitchState extends State<TUIToggleSwitch>
                   borderRadius: BorderRadius.circular(24.0),
                   color: _circleAnimation!.value == Alignment.centerLeft
                       ? isEnabled()
-                          ? colors.primary
+                          ? colors.surfaceVariant
                           : colors.disabledBackground
                       : isEnabled()
-                          ? colors.surfaceVariant
+                          ? colors.primary
                           : colors.disabledBackground,
                 ),
                 child: Padding(


### PR DESCRIPTION
Fixes #60

```
bool _enable = false;

@override
Widget build(BuildContext context) {
  Row(
    children: [
      TUIToggleSwitch(
        value: _enable,
        onChanged: (bool val) {
          setState(() {
            _enable = val;
          });
        },
      ),
      const SizedBox(
        width: 40,
      ),
      TUIToggleSwitch(
        value: _enable,
      ),
    ],
  ),
}

```
Will render the component like this now.


<img width="128" alt="Screenshot 2024-04-15 at 12 32 19 PM" src="https://github.com/tarkalabs/tarka-ui-kit-flutter/assets/5791518/b3bf01a5-18da-4b45-a41a-8e33492a985f">
