### PR TITLE
Add fields to text-field that makes text-field as text button with text-field style

### DIFF
--- a/lib/components/textfield/text_field.dart
+++ b/lib/components/textfield/text_field.dart
@@ -47,6 +47,9 @@ class TUIInputField extends StatelessWidget {
   final TextEditingController? controller;
   final TextInputType? keyboardType;
   final TextInputAction? textInputAction;
+  final bool canRequestFocus;
+  final bool? enableInteractiveSelection;
+  final MouseCursor? mouseCursor;
   final void Function(String)? onChanged;
   final void Function()? onEditingComplete;
   final void Function(String)? onSubmitted;
@@ -83,6 +86,9 @@ class TUIInputField extends StatelessWidget {
     this.onEditingComplete,
     this.onSubmitted,
     this.onTap,
+    this.canRequestFocus = true,
+    this.enableInteractiveSelection,
+    this.mouseCursor,
   })  : assert(maxLines == null || maxLines > 0),
         assert(minLines == null || minLines > 0),
         assert(
@@ -105,6 +111,9 @@ class TUIInputField extends StatelessWidget {
     final suffixIconColor = this.suffixIconColor ?? theme.colors.inputText;
     final prefixIconColor = this.prefixIconColor ?? theme.colors.inputText;
     return TextField(
+        mouseCursor: mouseCursor,
+        canRequestFocus: canRequestFocus,
+        enableInteractiveSelection: enableInteractiveSelection,
         onChanged: onChanged,
         onEditingComplete: onEditingComplete,
         onSubmitted: onSubmitted,


### PR DESCRIPTION
This change will enable us to have a clickable text field, that will not show the keyboard when clicked, and rather allow you to handle the click and show appropriate action as per requirement. for example: Showing Calendar for using it as date time field.